### PR TITLE
Fixed using types on queries parameters.

### DIFF
--- a/src/helpers/gqlConverters.js
+++ b/src/helpers/gqlConverters.js
@@ -3,12 +3,14 @@ const { camelCase, upperFirst } = require('lodash')
 const { BaseEntity } = require('gotu/src/baseEntity')
 const { pascalCase } = require('./stringCase')
 
-function requestFieldType2gql(type, presence) {
+function requestFieldType2gql(type, presence, input) {
     let name
     if (Array.isArray(type))
-        name = `[${requestFieldType2gql(type[0], false)}]`
+        name = `[${requestFieldType2gql(type[0], false, input)}]`
     else if (type === Number)
         name = `Float`
+    else if (type.prototype instanceof BaseEntity) 
+        name = `${upperFirst(camelCase(type.name))}${input ? 'Input' : ''}`
     else
         name = pascalCase(type.name)
 
@@ -20,7 +22,7 @@ function usecaseRequest2gql(useCase, presence) {
     const output = []
     for (const field of fields) {
         const type = useCase.requestSchema[field]
-        let name = requestFieldType2gql(type, presence)
+        let name = requestFieldType2gql(type, presence, true)
         output.push(`    ${field}: ${name}`)
 
     }
@@ -28,7 +30,7 @@ function usecaseRequest2gql(useCase, presence) {
 }
 
 function usecaseResponse2gql(useCase, presence) {
-    let name = requestFieldType2gql(useCase.responseSchema, presence)
+    let name = requestFieldType2gql(useCase.responseSchema, presence, false)
     return name
 }
 

--- a/test/usecase2mutation.test.js
+++ b/test/usecase2mutation.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const { usecase } = require('buchu')
+const { entity, field } = require('gotu')
 const { usecase2mutation } = require("../src/herbs2gql")
 const User = require('./support/gotu/users')
 
@@ -117,14 +118,21 @@ describe('UseCase 2GQL Mutation', () => {
             )
         })
 
-        it('should convert a usecase with primitive request params types and gotu array entity output to GQL', async () => {
+        it('should convert an usecase with entity types and entity array on request params types and gotu array entity output to GQL', async () => {
             // given
+            const GivenAnEntity = entity("Entity", {
+                numberField: field(Number),
+                customEntityFunction: function(){}        
+            })
+
             const givenAnUseCase = usecase('UseCaseTest', {
                 request: {
                     stringField: String,
                     numberField: Number,
                     dateField: Date,
-                    booleanField: Boolean
+                    booleanField: Boolean,
+                    entityField: GivenAnEntity,
+                    entityFieldArray: [GivenAnEntity]
                 },
 
                 response: [User]
@@ -135,7 +143,7 @@ describe('UseCase 2GQL Mutation', () => {
 
             // then
             assert.deepStrictEqual(gql,
-                `extend type Mutation {\n    useCaseTest (    stringField: String,\n    numberField: Float,\n    dateField: Date,\n    booleanField: Boolean) : [User]\n}`
+                `extend type Mutation {\n    useCaseTest (    stringField: String,\n    numberField: Float,\n    dateField: Date,\n    booleanField: Boolean,\n    entityField: EntityInput,\n    entityFieldArray: [EntityInput]) : [User]\n}`
             )
         })
     })

--- a/test/usecase2query.test.js
+++ b/test/usecase2query.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const { usecase } = require('buchu')
+const { entity, field } = require('gotu')
 const { usecase2query } = require("../src/herbs2gql")
 const User = require('./support/gotu/users')
 
@@ -138,6 +139,36 @@ describe('UseCase 2GQL Query', () => {
                 `extend type Query {\n    useCaseTest (    stringField: String,\n    numberField: Float,\n    dateField: Date,\n    booleanField: Boolean) : [User]\n}`
             )
         })
+
+        it('should convert a usecase with entity types and entity array on request params types and gotu array entity output to GQL', async () => {
+            // given
+            const GivenAnEntity = entity("Entity", {
+                numberField: field(Number),
+                customEntityFunction: function(){}        
+            })
+
+            const givenAnUseCase = usecase('UseCaseTest', {
+                request: {
+                    stringField: String,
+                    numberField: Number,
+                    dateField: Date,
+                    booleanField: Boolean,
+                    entityField: GivenAnEntity,
+                    entityFieldArray: [GivenAnEntity]
+                },
+
+                response: [User]
+            })
+
+            // when
+            const gql = usecase2query(givenAnUseCase)
+
+            // then
+            assert.deepStrictEqual(gql,
+                `extend type Query {\n    useCaseTest (    stringField: String,\n    numberField: Float,\n    dateField: Date,\n    booleanField: Boolean,\n    entityField: EntityInput,\n    entityFieldArray: [EntityInput]) : [User]\n}`
+            )
+        })
+        
     })
 
     context('when schema is required data', () => {

--- a/test/usecase2subscription.test.js
+++ b/test/usecase2subscription.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const { usecase } = require('buchu')
+const { entity, field } = require('gotu')
 const { usecase2subscription } = require("../src/herbs2gql")
 const User = require('./support/gotu/users')
 
@@ -214,14 +215,21 @@ describe('UseCase 2GQL Subscription', () => {
             )
         })
 
-        it('should convert a usecase with not nullable request params types and not nullable gotu array entity output to GQL', async () => {
+        it('should convert a usecase with not nullable, entity types and entity array on request params types and not nullable gotu array entity output to GQL', async () => {
             // given
+            const GivenAnEntity = entity("Entity", {
+                numberField: field(Number),
+                customEntityFunction: function(){}        
+            })
+
             const givenAnUseCase = usecase('UseCaseTest', {
                 request: {
                     stringField: String,
                     numberField: Number,
                     dateField: Date,
-                    booleanField: Boolean
+                    booleanField: Boolean,
+                    entityField: GivenAnEntity,
+                    entityFieldArray: [GivenAnEntity]
                 },
     
                 response: [User]
@@ -235,7 +243,7 @@ describe('UseCase 2GQL Subscription', () => {
     
             // then
             assert.deepStrictEqual(gql,
-                `extend type Subscription {\n    useCaseTest (    stringField: String!,\n    numberField: Float!,\n    dateField: Date!,\n    booleanField: Boolean!) : [User]!\n}`
+                `extend type Subscription {\n    useCaseTest (    stringField: String!,\n    numberField: Float!,\n    dateField: Date!,\n    booleanField: Boolean!,\n    entityField: EntityInput!,\n    entityFieldArray: [EntityInput]!) : [User]!\n}`
             )
         })
     })


### PR DESCRIPTION
On Graphql Queries (query, mutation, and subscription) types cant be used for input parameter objects, to this is necessary to uses 'Inputs' types, to do this, I added Input on `requestFieldType2gql` and adapted the logic for `usecaseResponse2gql` since they use the same method.