### PR TITLE
feat(defaultresolver): adds support to custom error handler on default resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,62 @@ const [gql, resolver] = usecase2mutation(usecase, resolverFunc)
 ​
 Or you can use `herbs2gql` [`defaultResolver`](https://github.com/herbsjs/herbs2gql/blob/master/src/defaultResolver.js) implementation as a reference. 
 ​
+#### Error Handling
+
+`herbs2gql` deals with errors in the default resolver. It translates the usecase's errors into graphql errors:
+
+| Usecase Error            | Apollo Error   |
+|--------------------------|----------------|
+| Permission Denied        | ForbiddenError |
+| Not Found                | ApolloError    |
+| Already Exists           | ApolloError    |
+| Unknown                  | ApolloError    |
+| Invalid Arguments        | UserInputError |
+| Invalid Entity           | UserInputError |
+| Any other kind of errors | UserInputError |
+
+However, it's behavior can be overridden in the `errorHandler` property of the options parameter:
+
+```javascript
+const { defaultResolver } = require('@herbsjs/herbs2gql')
+
+const myCustomErrorHandler = (usecaseResponse) => {
+    // handle the errors on your own way
+}
+
+const options = {
+    errorHandler: myCustomErrorHandler
+}
+
+const updateUser = usecase('Update User', {
+    // usecase implementation
+})
+
+const [gql, resolver] = usecase2mutation(updateUser(), defaultResolver(updateUser, options))
+```
+
+Your custom error handler can also utilize the `defaultErrorHandler` as a fallback:
+
+```javascript
+const { defaultResolver, defaultErrorHandler } = require('@herbsjs/herbs2gql')
+
+const myCustomErrorHandler = (usecaseResponse) => {
+    // handle the errors on your own way
+
+    // use the default error handler when there is no need of a specific treatment
+    return defaultErrorHandler(usecaseResponse)
+}
+
+const options = {
+    errorHandler: myCustomErrorHandler
+}
+
+const updateUser = usecase('Update User', {
+    // usecase implementation
+})
+
+const [gql, resolver] = usecase2mutation(updateUser(), defaultResolver(updateUser, options))
+```
 ​
 #### Custom Names or Conventions
 In Herbs it is possible to include personalized names for queries, mutations, inputs and types

--- a/src/defaultErrorHandler.js
+++ b/src/defaultErrorHandler.js
@@ -1,0 +1,19 @@
+const { UserInputError, ForbiddenError, ApolloError } = require('apollo-server-express')
+
+const defaultErrorHandler = function (usecaseResponse) {
+    if (usecaseResponse.isPermissionDeniedError)
+        throw new ForbiddenError(usecaseResponse.err.message, { cause: usecaseResponse.err })
+
+    if (usecaseResponse.isInvalidArgumentsError ||
+        usecaseResponse.isInvalidEntityError)
+        throw new UserInputError(usecaseResponse.err.message, { cause: usecaseResponse.err })
+
+    if (usecaseResponse.isNotFoundError ||
+        usecaseResponse.isAlreadyExistsError ||
+        usecaseResponse.isUnknownError)
+        throw new ApolloError(usecaseResponse.err.message, usecaseResponse.err.code, { cause: usecaseResponse.err })
+
+    throw new UserInputError(null, { cause: usecaseResponse.err })
+}
+
+module.exports = { defaultErrorHandler }

--- a/src/herbs2gql.js
+++ b/src/herbs2gql.js
@@ -5,5 +5,6 @@ module.exports = {
     usecase2query: require('./usecase2query'),
     usecase2subscription: require('./usecase2subscription'),
     defaultResolver: require('./defaultResolver'),
-    args2request : require('./args2request'),
+    defaultErrorHandler: require('./defaultErrorHandler').defaultErrorHandler,
+    args2request: require('./args2request'),
 }

--- a/test/defaultErrorHandler.test.js
+++ b/test/defaultErrorHandler.test.js
@@ -1,0 +1,174 @@
+const assert = require('assert')
+const { Err } = require('@herbsjs/herbs')
+const { defaultErrorHandler } = require('../src/defaultErrorHandler')
+
+describe('defaultErrorHandler', () => {
+    it('should throw ForbiddenError when usecase responds with permission denied error', () => {
+        const usecaseResponse = Err.permissionDenied({
+            message: 'Permission Denied X',
+            payload: {
+                entity: 'entity Y'
+            }
+        })
+
+        assert.throws(() => defaultErrorHandler(usecaseResponse), {
+            name: 'ForbiddenError',
+            message: 'Permission Denied X',
+            extensions: {
+                code: 'FORBIDDEN',
+                cause: {
+                    cause: undefined,
+                    code: 'PERMISSION_DENIED',
+                    message: 'Permission Denied X',
+                    payload: {
+                        entity: 'entity Y'
+                    }
+                }
+            }
+        })
+    })
+
+    it('should throw UserInputError when usecase responds with invalid arguments error', () => {
+        const usecaseResponse = Err.invalidArguments({
+            message: 'Invalid Arg X',
+            args: {
+                field: 1
+            },
+            payload: {
+                entity: 'entity Y'
+            }
+        })
+
+        assert.throws(() => defaultErrorHandler(usecaseResponse), {
+            name: 'UserInputError',
+            message: 'Invalid Arg X',
+            extensions: {
+                code: 'BAD_USER_INPUT',
+                cause: {
+                    cause: undefined,
+                    code: 'INVALID_ARGUMENTS',
+                    message: 'Invalid Arg X',
+                    payload: {
+                        entity: 'entity Y',
+                        invalidArgs: {
+                            field: 1
+                        }
+                    }
+                }
+            }
+        })
+    })
+
+    it('should throw UserInputError when usecase responds with invalid entity error', () => {
+        const usecaseResponse = Err.invalidEntity({
+            message: 'Invalid Arg X',
+            payload: {
+                entity: 'entity Y'
+            }
+        })
+
+        assert.throws(() => defaultErrorHandler(usecaseResponse), {
+            name: 'UserInputError',
+            message: 'Invalid Arg X',
+            extensions: {
+                code: 'BAD_USER_INPUT',
+                cause: {
+                    cause: undefined,
+                    code: 'INVALID_ENTITY',
+                    message: 'Invalid Arg X',
+                    payload: {
+                        entity: 'entity Y'
+                    }
+                }
+            }
+        })
+    })
+
+    it('should throw ApolloError when usecase responds with not found error', () => {
+        const usecaseResponse = Err.notFound({
+            message: 'Invalid Arg X',
+            payload: {
+                entity: 'entity Y'
+            }
+        })
+
+        assert.throws(() => defaultErrorHandler(usecaseResponse), {
+            name: 'Error',
+            message: 'Invalid Arg X',
+            extensions: {
+                code: 'NOT_FOUND',
+                cause: {
+                    cause: undefined,
+                    code: 'NOT_FOUND',
+                    message: 'Invalid Arg X',
+                    payload: {
+                        entity: 'entity Y'
+                    }
+                }
+            }
+        })
+    })
+
+    it('should throw ApolloError when usecase responds with already exists error', () => {
+        const usecaseResponse = Err.alreadyExists({
+            message: 'Invalid Arg X',
+            payload: {
+                entity: 'entity Y'
+            }
+        })
+
+        assert.throws(() => defaultErrorHandler(usecaseResponse), {
+            name: 'Error',
+            message: 'Invalid Arg X',
+            extensions: {
+                code: 'ALREADY_EXISTS',
+                cause: {
+                    cause: undefined,
+                    code: 'ALREADY_EXISTS',
+                    message: 'Invalid Arg X',
+                    payload: {
+                        entity: 'entity Y'
+                    }
+                }
+            }
+        })
+    })
+
+    it('should throw ApolloError when usecase responds with unknown error', () => {
+        const usecaseResponse = Err.unknown({
+            message: 'Invalid Arg X',
+            payload: {
+                entity: 'entity Y'
+            }
+        })
+
+        assert.throws(() => defaultErrorHandler(usecaseResponse), {
+            name: 'Error',
+            message: 'Invalid Arg X',
+            extensions: {
+                code: 'UNKNOWN',
+                cause: {
+                    cause: undefined,
+                    code: 'UNKNOWN',
+                    message: 'Invalid Arg X',
+                    payload: {
+                        entity: 'entity Y'
+                    }
+                }
+            }
+        })
+    })
+
+    it('should throw UserInputError when usecase responds with generic error', () => {
+        const usecaseResponse = Err('an error occurred')
+
+        assert.throws(() => defaultErrorHandler(usecaseResponse), {
+            name: 'UserInputError',
+            message: 'null',
+            extensions: {
+                cause: 'an error occurred',
+                code: 'BAD_USER_INPUT'
+            }
+        })
+    })
+})

--- a/test/defaultResolver.test.js
+++ b/test/defaultResolver.test.js
@@ -1,9 +1,8 @@
 const assert = require('assert')
-const { Ok, Err, usecase, step } = require('@herbsjs/herbs')
+const { Ok, usecase, step, Err } = require('@herbsjs/herbs')
 const defaultResolver = require('../src/defaultResolver')
 
 describe('GraphQL - Default Resolver', () => {
-
     it('should resolve and run a use case', async () => {
         // Given
         const AUseCase = () =>
@@ -22,208 +21,6 @@ describe('GraphQL - Default Resolver', () => {
 
         // Then
         assert.deepStrictEqual(ret, 'result')
-
-    })
-
-    it('should throw a UserInputError if the uc returns a Err', async () => {
-        // Given
-        const AUseCase = () =>
-            usecase('Use Case X', {
-                request: { id: Number },
-                response: Number,
-                authorize: async () => Ok(),
-                'Step 1': step(() => { return Err("error") }
-                )
-            })
-
-        const resolver = defaultResolver(AUseCase)
-
-        await assert.rejects(
-            // When
-            async () => {
-                await resolver(null, {}, { user: {} })
-            },
-            // Then
-            (err) => {
-                assert.strictEqual(err.name, 'UserInputError')
-                assert.strictEqual(err.extensions.cause, 'error')
-                return true
-            }
-        )
-    })
-
-    it('should throw a ForbiddenError if the uc returns a Err.permissionDenied', async () => {
-        // Given
-        const AUseCase = () =>
-            usecase('Use Case X', {
-                request: { id: Number },
-                response: Number,
-                authorize: async () => Ok(),
-                'Step 1': step(() => {
-                    return Err.permissionDenied({ message: `Permission Denied X`, payload: { entity: 'entity Y' } })
-                })
-            })
-
-        const resolver = defaultResolver(AUseCase)
-
-        await assert.rejects(
-            // When
-            async () => {
-                await resolver(null, {}, { user: {} })
-            },
-            // Then
-            (err) => {
-                assert.strictEqual(err.name, 'ForbiddenError')
-                assert.strictEqual(err.message, 'Permission Denied X')
-                assert.strictEqual(err.extensions.cause.code, 'PERMISSION_DENIED')
-                return true
-            }
-        )
-    })
-
-    it('should throw a UserInputError if the uc returns a Err.invalidArguments', async () => {
-        // Given
-        const AUseCase = () =>
-            usecase('Use Case X', {
-                request: { id: Number },
-                response: Number,
-                authorize: async () => Ok(),
-                'Step 1': step(() => {
-                    return Err.invalidArguments({ message: `Invalid Arg X`, payload: { entity: 'entity Y' } }, 'Arg X')
-                })
-            })
-
-        const resolver = defaultResolver(AUseCase)
-
-        await assert.rejects(
-            // When
-            async () => {
-                await resolver(null, {}, { user: {} })
-            },
-            // Then
-            (err) => {
-                assert.strictEqual(err.name, 'UserInputError')
-                assert.strictEqual(err.message, 'Invalid Arg X')
-                assert.strictEqual(err.extensions.cause.code, 'INVALID_ARGUMENTS')
-                return true
-            }
-        )
-    })
-
-    it('should throw a UserInputError if the uc returns a Err.invalidEntity', async () => {
-        // Given
-        const AUseCase = () =>
-            usecase('Use Case X', {
-                request: { id: Number },
-                response: Number,
-                authorize: async () => Ok(),
-                'Step 1': step(() => {
-                    return Err.invalidEntity({ message: `Invalid Entity X`, payload: { entity: 'entity Y' } })
-                })
-            })
-
-        const resolver = defaultResolver(AUseCase)
-
-        await assert.rejects(
-            // When
-            async () => {
-                await resolver(null, {}, { user: {} })
-            },
-            // Then
-            (err) => {
-                assert.strictEqual(err.name, 'UserInputError')
-                assert.strictEqual(err.message, 'Invalid Entity X')
-                assert.strictEqual(err.extensions.cause.code, 'INVALID_ENTITY')
-                return true
-            }
-        )
-    })
-
-    it('should throw a ApolloError if the uc returns a Err.notFound', async () => {
-        // Given
-        const AUseCase = () =>
-            usecase('Use Case X', {
-                request: { id: Number },
-                response: Number,
-                authorize: async () => Ok(),
-                'Step 1': step(() => {
-                    return Err.notFound({ message: `Not Found X`, payload: { entity: 'entity Y' } })
-                })
-            })
-
-        const resolver = defaultResolver(AUseCase)
-
-        await assert.rejects(
-            // When
-            async () => {
-                await resolver(null, {}, { user: {} })
-            },
-            // Then
-            (err) => {
-                assert.strictEqual(err.name, 'Error')
-                assert.strictEqual(err.message, 'Not Found X')
-                assert.strictEqual(err.extensions.cause.code, 'NOT_FOUND')
-                return true
-            }
-        )
-    })
-
-    it('should throw a ApolloError if the uc returns a Err.alreadyExists', async () => {
-        // Given
-        const AUseCase = () =>
-            usecase('Use Case X', {
-                request: { id: Number },
-                response: Number,
-                authorize: async () => Ok(),
-                'Step 1': step(() => {
-                    return Err.alreadyExists({ message: `Already Exists X`, payload: { entity: 'entity Y' } })
-                })
-            })
-
-        const resolver = defaultResolver(AUseCase)
-
-        await assert.rejects(
-            // When
-            async () => {
-                await resolver(null, {}, { user: {} })
-            },
-            // Then
-            (err) => {
-                assert.strictEqual(err.name, 'Error')
-                assert.strictEqual(err.message, 'Already Exists X')
-                assert.strictEqual(err.extensions.cause.code, 'ALREADY_EXISTS')
-                return true
-            }
-        )
-    })
-
-    it('should throw a ApolloError if the uc returns a Err.unknown', async () => {
-        // Given
-        const AUseCase = () =>
-            usecase('Use Case X', {
-                request: { id: Number },
-                response: Number,
-                authorize: async () => Ok(),
-                'Step 1': step(() => {
-                    return Err.unknown({ message: `Unknown X`, payload: { entity: 'entity Y' } })
-                })
-            })
-
-        const resolver = defaultResolver(AUseCase)
-
-        await assert.rejects(
-            // When
-            async () => {
-                await resolver(null, {}, { user: {} })
-            },
-            // Then
-            (err) => {
-                assert.strictEqual(err.name, 'Error')
-                assert.strictEqual(err.message, 'Unknown X')
-                assert.strictEqual(err.extensions.cause.code, 'UNKNOWN')
-                return true
-            }
-        )
     })
 
     it('should not run a use case if not autorized and throw a ForbiddenError', async () => {
@@ -247,6 +44,44 @@ describe('GraphQL - Default Resolver', () => {
                 return true
             }
         )
+    })
+
+    it('should use the custom error handler when it is provided on options', async () => {
+        const tracker = new assert.CallTracker()
+        const customErrorHandler = tracker.calls(() => { })
+
+        const myUsecase = () => usecase('My Usecase', {
+            request: {},
+            authorize: () => Ok(),
+            'step': step(() => Err('error'))
+        })
+
+        const resolver = defaultResolver(myUsecase, {
+            errorHandler: customErrorHandler
+        })
+
+        await resolver(null, {}, { user: {} })
+
+        process.on('exit', () => {
+            tracker.verify()
+        })
+    })
+
+    it('should use the default error handler when no custom handler is provided on options', async () => {
+        const myUsecase = () => usecase('My Usecase', {
+            request: {},
+            authorize: () => Ok(),
+            'step': step(() => Err('error'))
+        })
+
+        const resolver = defaultResolver(myUsecase, {})
+
+        await assert.rejects(
+            async () => await resolver(null, {}, { user: {} }),
+            (err) => {
+                assert.equal(err.name, 'UserInputError')
+                return true
+            })
     })
 })
 


### PR DESCRIPTION
It adds support to receive a custom error handler on the default resolver. If none is provided, so
it uses the default error handler.

fix #23

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Moved the error handling on defaultResolver to a separated file.
2. Added a parameter called `options` on defaultResolver. It has a property called `errorHandler` that is set to the `defaultErrorhandler` when none is provided. I decided to receive an `options` object instead of a simple `errorHandler` function because it is easier to extends these functionalities (like overriding another behavior) without creating breaking chances or adding more parameters.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
