### PR TITLE
Fix: array of entities as field of another entity

### DIFF
--- a/src/helpers/gqlConverters.js
+++ b/src/helpers/gqlConverters.js
@@ -24,7 +24,6 @@ function usecaseRequest2gql(useCase, presence) {
         const type = useCase.requestSchema[field]
         let name = requestFieldType2gql(type, presence, true)
         output.push(`${field}: ${name}`)
-
     }
     return output.join(`, `)
 }
@@ -43,7 +42,7 @@ function schemaOptions(options) {
 
 function entityFieldType2gql(type, param) {
     let name
-    if (Array.isArray(type)) name = `[${entityFieldType2gql(type[0])}]`
+    if (Array.isArray(type)) name = `[${entityFieldType2gql(type[0], param)}]`
     else if (type === Number) name = `Float`
     else if (type.prototype instanceof BaseEntity) {
         if(param == 'type')  name = upperFirst(camelCase(type.name))

--- a/test/entity2type.test.js
+++ b/test/entity2type.test.js
@@ -132,6 +132,7 @@ dateArrayField: [Date]
 
       const givenAnSecondEntity = entity("Entity Two", {
         entityField: field(givenAnFirstEntity),
+        entityList: field([givenAnFirstEntity]),
         customEntityFunction: function () { }
       })
 
@@ -147,6 +148,7 @@ numberField: Float
 }
       type EntityTwo {
 entityField: EntityOne
+entityList: [EntityOne]
 }`
       )
     })


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- [Link to issue if there is one](https://github.com/herbsjs/todolist-on-herbs/issues/106) -->
<!-- markdownlint-disable -->

Fixes #[106](https://github.com/herbsjs/todolist-on-herbs/issues/106)

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->
Adds support to use an array of entities as a field inside another entity

## Proposed Changes

1. Fix the **entityFieldType2gql** function to accept array of entities

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
